### PR TITLE
viz! open fix for Linux

### DIFF
--- a/ruby-lib/repl-utils.rb
+++ b/ruby-lib/repl-utils.rb
@@ -1,4 +1,8 @@
+require_relative 'sys-utils'
+
 module ReplUtils
+  include SysUtils
+  
   def example!
     #Demonstrate object creation and referencing by a variable
     @greeting = Example::String.new("Hello")
@@ -21,12 +25,9 @@ module ReplUtils
   end
 
   def viz!
-    open_is_present = system('command -v open >/dev/null 2>&1')
-    if open_is_present
-      system('open viz.html')
-    else
-      puts "The `open` executable cannot be found in your PATH"
-    end
+    puts 'The `open` executable cannot be found in your PATH or `open` command is '\
+         'not available for you current system, sorry. Please open viz.html directly '\
+         'in your browser.' unless SysUtils::open('viz.html')
   end
 
   def graph_report

--- a/ruby-lib/repl-utils.rb
+++ b/ruby-lib/repl-utils.rb
@@ -1,8 +1,6 @@
 require_relative 'sys-utils'
 
-module ReplUtils
-  include SysUtils
-  
+module ReplUtils  
   def example!
     #Demonstrate object creation and referencing by a variable
     @greeting = Example::String.new("Hello")

--- a/ruby-lib/sys-utils.rb
+++ b/ruby-lib/sys-utils.rb
@@ -1,0 +1,18 @@
+# System specific commanfs 
+module SysUtils
+  
+  class << self
+    def open(command)
+      if system("xdg-open #{command}")
+        true
+      else
+        open_is_present = system('command -v open >/dev/null 2>&1')
+        if open_is_present
+          system("open #{command}") 
+        else
+          false
+        end
+      end
+    end
+  end  
+end


### PR DESCRIPTION
Hello Matt,

This pull request addresses an issue that described here (support Linux for viz! command):
https://github.com/mattbaker/ruby-heap-viz/issues/1

Actually, using OS detection techniques to determine a Linux distro is not so clear and trivial... and I add a well-known xdg-open command attempt prior to open, which is standardized and available in most Linux distributions.

Thank you for your very nice tool.

P.S.: And you're right, open command on Linux is unrelated to open a file and I get exactly the same error on my Ubuntu 14.04.

WBR,
Knigin Yury
